### PR TITLE
Initial scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Development & Contribution Guide
+
+This document spells out how to tackle tasks in the **Rails SaaS Starter Template** project.  It isn’t a legal contract – it’s a practical set of tips that help you deliver high‑quality work and keep the project moving.
+
+## 1. Picking a task
+
+1. **Review the project board.**  The [Rails SaaS Starter Template project board](https://github.com/users/mitchellfyi/projects/2) lists all open issues.  Each issue represents a discrete piece of work with a defined outcome.
+2. **Choose something you can finish.**  Take an issue that matches your skillset and availability.  Don’t bite off more than you can chew – the goal is to complete tasks, not to hoard them.
+3. **Clarify before you start.**  If the issue description is ambiguous, raise a question in the issue thread.  Better to surface assumptions early than to rework later.
+
+## 2. Planning your work
+
+1. **Break it down.**  Decompose the issue into smaller steps: API design, database migrations, models, views, controllers, background jobs, tests, etc.  Sketch the flow on paper or in a gist.
+2. **Check existing patterns.**  This template emphasises consistency.  Look at existing modules (e.g. `ai/` or `billing/`) for conventions on naming, structure, and patterns.  Reuse helpers and libraries rather than inventing new ones.
+3. **Consider maintainability.**  Avoid hacks and shortcuts.  Favour clear, modular code with a single responsibility.  Document assumptions and trade‑offs in the code comments or the issue thread.
+
+## 3. Completing the task
+
+1. **Work on a branch.**  Create a new branch off `main` with a descriptive name (`feature/mcp-fetcher`, `fix/ai-test-timeouts`, etc.).
+2. **Implement iteratively.**  Commit early and often.  Keep commits focused on a single concern (e.g. one commit for models, one for controllers, one for tests).  Use meaningful commit messages – no “fix stuff”.
+3. **Write tests first.**  Whether you use RSpec or Minitest, start with failing tests that capture the desired behaviour.  Include unit tests (models, services), integration tests (controllers, background jobs), and system tests where appropriate.
+4. **Follow best practices.**  Use the latest Rails idioms.  Avoid N+1 queries, handle errors gracefully, and guard against security issues (SQL injection, mass assignment, cross‑site scripting).  Keep modules decoupled and respect boundaries.
+5. **Document your changes.**  Update relevant README sections, API documentation, and module guides.  If you introduce a new environment variable or configuration flag, document it in `.env.example` and the deployment guides.
+
+## 4. Testing & verification
+
+1. **Run the full test suite.**  Use `bin/rails test` or `bundle exec rspec` depending on your chosen framework.  Run integration/system tests to verify user flows.  The continuous integration (CI) pipeline runs the template installation and full test suite; make sure it passes locally before pushing.
+2. **Check code quality.**  Lint your code with RuboCop and run JavaScript linters (if you touched client code).  Fix style violations and warnings.
+3. **Verify against the original task.**  Re‑read the issue description and ensure that your implementation covers all acceptance criteria.  Be critical: would you sign off on this change if someone else submitted it?
+4. **Peer review.**  Open a pull request (PR) and request review from a colleague.  Incorporate feedback promptly.  Be open to changes – this project values collaborative improvement over ego.
+
+## 5. Planning new project tasks
+
+1. **Identify gaps.**  As you work, you may spot missing features or refactoring opportunities.  Don’t cram them into your current PR.  Instead, create a new issue in the project board with a clear title and description.
+2. **Use the template.**  For each new task, follow the established structure: concise title, well‑scoped description, acceptance criteria, and links to relevant code or discussions.
+3. **Prioritise impact.**  Not all tasks are equal.  Focus on items that deliver value to users or improve the codebase’s stability and maintainability.  Avoid “busy work”.
+
+## 6. Final thoughts
+
+This template is for serious engineers building AI‑native SaaS products.  Treat it like a real product: write robust code, test thoroughly, and be mindful of future maintainers.  Your contributions should make life easier for the next person who touches the code.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Most Rails templates are either toy examples or opinionated stacks that become b
 1. **Install prerequisites.**  You’ll need a recent Ruby (matching Rails Edge), Node.js/Yarn, PostgreSQL (with the `pgvector` extension), Redis, and Fly.io or Render CLI if you plan to deploy.
 2. **Create your app.**  Run:
 
-   ```sh
-   rails new myapp --dev -m https://example.com/template.rb
    cd myapp
    
    # Boot the application

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# Rails SaaS Starter Template
+
+This project is a fully‑featured template for building AI‑native SaaS applications on top of **Rails Edge**.  It combines a production‑ready base stack with modular features, long‑term maintainability, and first‑class support for large language models (LLMs).  You can bootstrap a new application with a single command and extend it via a clean CLI.
+
+## Why another template?
+
+Most Rails templates are either toy examples or opinionated stacks that become brittle over time.  This template is designed for serious engineers who need:
+
+* **Production‑grade defaults** (PostgreSQL, pgvector, Sidekiq, Redis, Devise, OmniAuth, JSON:API, OpenAPI, CI/CD, deploy configs);
+* **AI‑native support** with prompt templates, an asynchronous LLM job system, and a multi‑context provider (MCP) for enriching prompts;
+* **Modular architecture** that allows you to add or remove features cleanly via a command‑line tool (`bin/synth`);
+* **Comprehensive tests** that ensure the generated app boots and passes its suite out of the box;
+* **Extensibility** to suit real‑world product requirements without rewriting the core.
+
+## Getting started
+
+1. **Install prerequisites.**  You’ll need a recent Ruby (matching Rails Edge), Node.js/Yarn, PostgreSQL (with the `pgvector` extension), Redis, and Fly.io or Render CLI if you plan to deploy.
+2. **Create your app.**  Run:
+
+   ```sh
+   rails new myapp --dev -m https://example.com/template.rb
+   cd myapp
+   
+   # Boot the application
+   bin/setup
+   bin/dev
+   ```
+
+   The `--dev` flag uses Rails Edge.  The template script will install TailwindCSS, set up the database, integrate Sidekiq, configure Devise/OmniAuth, and scaffold a default workspace/team model.
+
+3. **Explore `bin/synth`.**  The CLI tool allows you to manage feature modules:
+
+   ```sh
+   bin/synth list            # Show installed modules
+   bin/synth add ai          # Add AI/LLM support
+   bin/synth add billing     # Add Stripe billing
+   bin/synth remove cms      # Remove the CMS/blog engine
+   bin/synth upgrade         # Pull in latest module versions
+   bin/synth test ai         # Run AI tests
+   bin/synth doctor          # Validate your setup (keys, MCP fetchers)
+   bin/synth scaffold agent chatbot_support
+   ```
+
+4. **Configure your environment.**  Copy `.env.example` to `.env` and fill in secrets for Devise, OmniAuth providers, Stripe API keys, and LLM providers.  Configure your database (`config/database.yml`) and set up Redis.
+
+5. **Run the test suite.**  Execute `bin/rails test` (Minitest) or `bundle exec rspec` if you installed RSpec.  The template ships with mocks for external services and ensures that the default install passes all tests.
+
+## Features
+
+### Base stack
+
+* **Rails Edge** (`--dev`) with Hotwire (Turbo & Stimulus) and TailwindCSS.
+* **PostgreSQL** with `pgvector` extension for semantic embeddings.
+* **Redis & Sidekiq** for background job processing.
+* **Devise** for email/password authentication with confirmation, lockout, two‑factor support.
+* **OmniAuth** for OAuth logins (Google, GitHub, Slack).
+* **Workspaces/teams** with slug routing, invitation system, and role/permission management.
+* **JSON:API‑compliant APIs** with automatically generated **OpenAPI** schema.
+* **Stripe billing** with free trials, subscriptions, metered billing, coupons, one‑off charges, and PDF invoices.
+* **CMS/blog engine** powered by ActionText with WYSIWYG editor, SEO metadata, and sitemap generation.
+* **Admin panel** with impersonation, audit logs, Sidekiq UI, and feature flag toggles.
+* **Internationalisation** (i18n) with locale detection, right‑to‑left support, and currency/date formatting.
+* **CI/CD** templates for GitHub Actions, plus deployment configs for Fly.io, Render, and Kamal.
+
+### AI system
+
+* **Prompt templates** with versioning, variable interpolation, tags, output types (JSON, Markdown, HTML partial), previews, and diffs.
+* **Asynchronous LLM jobs** with Sidekiq: `LLMJob.perform_later(template:, model:, context:, format:)` executes prompts, logs inputs/outputs, handles retries with exponential backoff, and stores results in `LLMOutput`.  Users can give feedback (thumbs up/down), re‑run, or regenerate jobs.
+* **Multi‑Context Provider (MCP)** for dynamic prompt context.  Fetch data from database queries, HTTP APIs (GitHub, Slack), file/document parsing, semantic memory via embeddings, and code introspection.  Compose fetchers via `context.fetch(:key, params)` to produce a hash for prompt templates.  Developers can register custom fetchers.
+
+### CLI (`bin/synth`)
+
+The `bin/synth` tool is a Thor‑based CLI that manages modules in the `lib/templates/synth/` directory.  Modules encapsulate features like `auth`, `billing`, `ai`, `mcp`, `cms`, `admin`, `deploy`, `testing`, `api`, and `docs`.  Each module includes installation scripts, migrations, seeds, and a README.  The CLI logs its actions to `log/synth.log` and provides commands to scaffold new agents for AI features.
+
+### Testing
+
+The template encourages full test coverage.  Every module ships with unit, integration, and system tests.  External services (OpenAI, Claude, Stripe, GitHub) are stubbed to ensure deterministic runs.  The GitHub Actions workflow (`.github/workflows/test.yml`) installs the template into a fresh app and runs the full suite across a matrix of Ruby and PostgreSQL versions.
+
+### Seeding
+
+Seed data sets up a demo organisation with a user, example prompt templates, example LLM jobs and outputs, dummy Stripe plans, and a sample blog post.  Seeds are idempotent, meaning you can run them multiple times without duplicating data.
+
+## Contributing
+
+Contributions are welcome!  Please read **AGENTS.md** for detailed instructions on picking tasks, planning, implementing, testing, and verifying work.  In short:
+
+1. Pick an open issue from the project board.
+2. Create a branch and implement the feature with tests.
+3. Keep commits small and focused; follow established patterns.
+4. Update documentation where needed.
+5. Open a PR, link it to the issue, and request review.
+
+## License
+
+This project is provided under the [MIT License](LICENSE).  See `LICENSE` for details.

--- a/scaffold/bin/synth
+++ b/scaffold/bin/synth
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'thor'
+require_relative '../../lib/synth/cli'
+
+Synth::CLI.start(ARGV)

--- a/scaffold/lib/synth/cli.rb
+++ b/scaffold/lib/synth/cli.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'thor'
+
+module Synth
+  class CLI < Thor
+    desc 'new', 'Setup scaffolding for new application'
+    def new
+      puts 'Running synth new...'
+    end
+
+    desc 'add MODULE', 'Add a feature module to your app'
+    def add(feature)
+      puts "Adding module #{feature}..."
+    end
+
+    desc 'remove MODULE', 'Remove a feature module from your app'
+    def remove(feature)
+      puts "Removing module #{feature}..."
+    end
+
+    desc 'list', 'List installed modules and versions'
+    def list
+      puts 'Listing installed modules...'
+    end
+
+    desc 'upgrade', 'Upgrade installed modules'
+    def upgrade
+      puts 'Upgrading modules...'
+    end
+
+    desc 'test [MODULE]', 'Run tests; if MODULE specified, run tests only for that module'
+    def test(feature = nil)
+      if feature.nil?
+        puts 'Running full test suite...'
+      else
+        puts "Running tests for #{feature}..."
+      end
+    end
+
+    desc 'doctor', 'Validate setup, keys, and MCP fetchers'
+    def doctor
+      puts 'Running synth doctor...'
+    end
+
+    desc 'scaffold AGENT', 'Scaffold an agent'
+    def scaffold(name)
+      puts "Scaffolding agent #{name}..."
+    end
+  end
+end

--- a/scaffold/lib/templates/synth/ai/README.md
+++ b/scaffold/lib/templates/synth/ai/README.md
@@ -1,0 +1,27 @@
+# AI Module
+
+This module adds first‑class AI integration to your Rails app. It installs prompt templates, an LLM job runner, and context providers for multi‑context prompts.
+
+## Installation
+
+Run the following command from your application root to install the AI module via the Synth CLI:
+
+```
+bin/synth add ai
+```
+
+This command will add the necessary gems, copy configuration files, run migrations, and set up initial prompt templates.
+
+## Customisation
+
+The AI module ships with sensible defaults but is designed for extension. Review `install.rb` for details on what is installed. You can customise prompt templates, LLM models, and context fetchers by editing the generated files in your application.
+
+## Next steps
+
+After installation, configure your OpenAI or other LLM API keys in the appropriate credentials file. Run the test suite to ensure the AI components are functioning as expected:
+
+```
+bin/synth test ai
+```
+
+Contributions and improvements are welcome. Keep this README up to date as the module evolves.

--- a/scaffold/lib/templates/synth/ai/install.rb
+++ b/scaffold/lib/templates/synth/ai/install.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Synth AI module installer for the Rails SaaS starter template.
+# This install script is executed by the bin/synth CLI when adding the AI module.
+# It is intentionally minimal; extend it to install generators, migrations, and configuration as needed.
+
+say_status :synth_ai, "Installing AI module"
+
+# Add AI specific gems to the application's Gemfile
+add_gem 'ruby-openai'
+add_gem 'pgvector'
+
+# Run bundle install and set up AI configuration after gems are installed
+after_bundle do
+  # Create an initializer for AI configuration
+  initializer 'ai.rb', <<~'RUBY'
+    # AI module configuration
+    # Set your default model and any other AI related settings here
+    Rails.application.config.ai = ActiveSupport::OrderedOptions.new
+    Rails.application.config.ai.default_model = 'gpt-4'
+  RUBY
+
+  # TODO: generate models, migrations, and other scaffolding for prompt templates and LLM outputs
+  say_status :synth_ai, "AI module installed. Please run migrations and configure your API keys."
+end

--- a/scaffold/lib/templates/synth/ai/install.rb
+++ b/scaffold/lib/templates/synth/ai/install.rb
@@ -8,7 +8,6 @@ say_status :synth_ai, "Installing AI module"
 
 # Add AI specific gems to the application's Gemfile
 add_gem 'ruby-openai'
-add_gem 'pgvector'
 
 # Run bundle install and set up AI configuration after gems are installed
 after_bundle do

--- a/scaffold/template.rb
+++ b/scaffold/template.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# Template script for generating a new Rails SaaS Starter application.
+#
+# Usage:
+#   rails new myapp --dev -m https://example.com/template.rb
+#
+# This script will guide you through setting up the base stack for the
+# Rails SaaS Starter Template.  It appends necessary gems to your
+# Gemfile, runs generators for authentication, background jobs, and
+# Tailwind/Hotwire, and scaffolds workspace/team models.  It also
+# installs a command‑line interface (`bin/synth`) and a default AI
+# module skeleton.  Feel free to customise this script to suit your
+# project’s needs.
+
+say "🪝 Setting up Rails SaaS Starter Template..."
+
+# Add gems to the Gemfile
+gem 'pg', '~> 1.5'
+gem 'pgvector', '~> 0.5'
+gem 'redis', '~> 4.8'
+gem 'sidekiq', '~> 7.0'
+gem 'devise', '~> 4.9'
+gem 'omniauth', '~> 2.1'
+gem 'stripe', '~> 8.0'
+gem 'pundit', '~> 2.1'
+gem 'turbo-rails', '~> 1.5'
+gem 'stimulus-rails', '~> 1.2'
+gem 'tailwindcss-rails', '~> 0.8'
+gem 'jsonapi-serializer', '~> 3.2'
+gem 'rswag', '~> 2.14'
+gem_group :development, :test do
+  gem 'dotenv-rails', '~> 3.1'
+  gem 'factory_bot_rails', '~> 6.2'
+  gem 'faker', '~> 3.3'
+  gem 'rspec-rails', '~> 6.0'
+end
+
+after_bundle do
+  # Install Hotwire and Tailwind
+  rails_command 'turbo:install'
+  rails_command 'stimulus:install'
+  rails_command 'tailwindcss:install'
+
+  # Set up authentication with Devise
+  generate 'devise:install'
+  generate 'devise', 'User'
+
+  # Configure Sidekiq as the Active Job backend
+  environment "config.active_job.queue_adapter = :sidekiq", env: %w[development production test]
+
+  # Scaffold workspace/team models
+  generate :model, 'Workspace', 'name:string', 'slug:string'
+  generate :model, 'Membership', 'workspace:references', 'user:references', 'role:string'
+
+  # Mount Sidekiq web UI behind authentication (requires admin? method on User)
+  route "require 'sidekiq/web'\nauthenticate :user, lambda { |u| u.respond_to?(:admin?) && u.admin? } do\n  mount Sidekiq::Web => '/admin/sidekiq'\nend"
+
+  # Create bin/synth CLI
+  run 'mkdir -p bin'
+  create_file 'bin/synth', <<~RUBY
+    #!/usr/bin/env ruby
+    # frozen_string_literal: true
+
+    require 'thor'
+    require_relative '../lib/synth/cli'
+
+    Synth::CLI.start(ARGV)
+  RUBY
+  run 'chmod +x bin/synth'
+
+  # Create CLI implementation
+  run 'mkdir -p lib/synth'
+  create_file 'lib/synth/cli.rb', <<~RUBY
+    # frozen_string_literal: true
+
+    require 'thor'
+
+    module Synth
+      class CLI < Thor
+        desc 'list', 'List installed modules'
+        def list
+          modules_path = File.expand_path('../templates/synth', __dir__)
+          puts 'Installed modules:'
+          if Dir.exist?(modules_path)
+            Dir.children(modules_path).each { |m| puts "  - #{m}" }
+          else
+            puts '  (none)'
+          end
+        end
+
+        desc 'add MODULE', 'Add a module (e.g. billing, ai)'
+        def add(module_name)
+          puts "[stub] Add module: #{module_name}"
+          # TODO: implement installer loading lib/templates/synth/<module>/install.rb
+        end
+
+        desc 'remove MODULE', 'Remove a module'
+        def remove(module_name)
+          puts "[stub] Remove module: #{module_name}"
+        end
+
+        desc 'upgrade', 'Upgrade installed modules'
+        def upgrade
+          puts '[stub] Upgrade modules'
+        end
+
+        desc 'test ai', 'Run AI tests'
+        def test(_name = 'ai')
+          puts '[stub] Run AI tests'
+        end
+
+        desc 'doctor', 'Validate setup and keys'
+        def doctor
+          puts '[stub] Run diagnostics'
+        end
+
+        desc 'scaffold agent NAME', 'Scaffold a new AI agent'
+        def scaffold(name)
+          puts "[stub] Scaffold agent: #{name}"
+        end
+      end
+    end
+  RUBY
+
+  # Create an example AI module skeleton
+  run 'mkdir -p lib/templates/synth/ai'
+  create_file 'lib/templates/synth/ai/install.rb', <<~RUBY
+    # frozen_string_literal: true
+
+    # Example installer for the AI module.  In a real implementation this
+    # would create models, migrations, jobs, controllers, and tests for
+    # prompt templates, LLM jobs, and MCP integration.
+    say 'Installing AI module...'
+    # TODO: implement prompt template models and LLM job system
+  RUBY
+  create_file 'lib/templates/synth/ai/README.md', <<~MD
+    # AI Module
+
+    Provides prompt templates, asynchronous LLM job processing, and a multi‑context provider (MCP).
+
+    - **Prompt templates** store prompts with variables, tags, and versions.
+    - **LLM jobs** run prompts asynchronously via Sidekiq, handling retries and logging inputs/outputs.
+    - **MCP** fetches context from your database, external APIs, files, semantic memory, or code.
+
+    Install this module via:
+
+    ```sh
+    bin/synth add ai
+    ```
+
+    It will add the necessary models, migrations, routes, controllers, and tests.
+  MD
+end
+
+say "✅ Template setup complete.  Run `bin/setup` to finish configuring your application."

--- a/scaffold/template.rb
+++ b/scaffold/template.rb
@@ -17,23 +17,23 @@ say "🪝 Setting up Rails SaaS Starter Template..."
 
 # Add gems to the Gemfile
 gem 'pg', '~> 1.5'
-gem 'pgvector', '~> 0.5'
-gem 'redis', '~> 4.8'
-gem 'sidekiq', '~> 7.0'
+gem 'pgvector', '~> 0.3.2'
+gem 'redis', '~> 5.4'
+gem 'sidekiq', '~> 8.0'
 gem 'devise', '~> 4.9'
 gem 'omniauth', '~> 2.1'
-gem 'stripe', '~> 8.0'
+gem 'stripe', '~> 15.3'
 gem 'pundit', '~> 2.1'
 gem 'turbo-rails', '~> 1.5'
 gem 'stimulus-rails', '~> 1.2'
-gem 'tailwindcss-rails', '~> 0.8'
+gem 'tailwindcss-rails', '~> 4.3'
 gem 'jsonapi-serializer', '~> 3.2'
 gem 'rswag', '~> 2.14'
 gem_group :development, :test do
   gem 'dotenv-rails', '~> 3.1'
   gem 'factory_bot_rails', '~> 6.2'
   gem 'faker', '~> 3.3'
-  gem 'rspec-rails', '~> 6.0'
+  gem 'rspec-rails', '~> 8.0'
 end
 
 after_bundle do


### PR DESCRIPTION
This pull request introduces the initial scaffold for the Rails SaaS starter template.

- Adds `AGENTS.md` with guidelines on how to pick up tasks, develop them, test thoroughly, and follow best practices.
- Adds a comprehensive `README.md` outlining the project's purpose, stack, AI system, CLI usage, and installation instructions.
- Provides `scaffold/template.rb`, a Rails template script to set up the base stack (PostgreSQL, TailwindCSS, Hotwire, Devise, etc.) when running `rails new --dev`.
- Adds `scaffold/bin/synth`, a CLI tool used to manage modules (add/remove/list/upgrade/test/doctor/scaffold).
- Adds `scaffold/lib/synth/cli.rb` which defines the Thor-based CLI commands used by `bin/synth`.
- Introduces the AI module in `scaffold/lib/templates/synth/ai` with an `install.rb` script and accompanying `README.md` stub for extending AI functionality.

This sets the foundation for future modules and tasks to be built upon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive Rails SaaS starter template with production-ready defaults, modular architecture, and built-in AI/LLM support.
  * Added a command-line interface (CLI) tool for managing modular features, scaffolding, and diagnostics.
  * Provided an AI module with prompt templates, LLM job runner, and multi-context support, including installation and configuration scripts.
* **Documentation**
  * Added detailed README files for the main project and AI module, including setup instructions, feature overviews, and contribution guidelines.
  * Introduced a contributor guide outlining development and collaboration best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->