### PR TITLE
Add 2FA and OmniAuth providers, rolify/friendly_id to template

### DIFF
--- a/scaffold/template.rb
+++ b/scaffold/template.rb
@@ -160,9 +160,3 @@ after_bundle do
 end
 
 say "✅ Template setup complete.  Run `bin/setup` to finish configuring your application."
-gem 'rolify', '~> 6.0'
-gem 'friendly_id', '~> 5.4'
-gem 'devise-two-factor', '~> 4.0'
-gem 'omniauth-google-oauth2', '~> 1.0'
-gem 'omniauth-github', '~> 2.0'
-gem 'omniauth-slack', '~> 2.0'

--- a/scaffold/template.rb
+++ b/scaffold/template.rb
@@ -20,7 +20,9 @@ gem 'pg', '~> 1.5'
 gem 'pgvector', '~> 0.5'
 gem 'redis', '~> 4.8'
 gem 'sidekiq', '~> 7.0'
+
 gem 'devise', '~> 4.9'
+
 gem 'omniauth', '~> 2.1'
 gem 'stripe', '~> 8.0'
 gem 'pundit', '~> 2.1'
@@ -82,7 +84,9 @@ after_bundle do
         def list
           modules_path = File.expand_path('../templates/synth', __dir__)
           puts 'Installed modules:'
+
           if Dir.exist?(modules_path)
+
             Dir.children(modules_path).each { |m| puts "  - #{m}" }
           else
             puts '  (none)'
@@ -115,12 +119,14 @@ after_bundle do
           puts '[stub] Run diagnostics'
         end
 
+
         desc 'scaffold agent NAME', 'Scaffold a new AI agent'
         def scaffold(name)
           puts "[stub] Scaffold agent: #{name}"
         end
       end
     end
+
   RUBY
 
   # Create an example AI module skeleton
@@ -154,3 +160,9 @@ after_bundle do
 end
 
 say "✅ Template setup complete.  Run `bin/setup` to finish configuring your application."
+gem 'rolify', '~> 6.0'
+gem 'friendly_id', '~> 5.4'
+gem 'devise-two-factor', '~> 4.0'
+gem 'omniauth-google-oauth2', '~> 1.0'
+gem 'omniauth-github', '~> 2.0'
+gem 'omniauth-slack', '~> 2.0'


### PR DESCRIPTION
This PR adds additional gems to the Rails SaaS Starter template to support roles, slug routing, two-factor authentication and common OAuth providers.

- Adds `rolify` and `friendly_id` for role management and friendly URLs.
- Adds `devise-two-factor` to support two-factor authentication in Devise.
- Adds `omniauth-google-oauth2`, `omniauth-github`, and `omniauth-slack` to support OAuth logins via Google, GitHub and Slack.

The gems are appended near the end of `scaffold/template.rb`. Follow-up work will integrate these features into the generated app. This PR supports the "Base stack setup" task.